### PR TITLE
Fix order of releases in the output map

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
     :alt: Travis-CI Build Status
     :target: https://travis-ci.org/ansasaki/abimap
 
-.. |coveralls| image:: https://coveralls.io/repos/ansasaki/abimap/badge.svg?branch=master
+.. |coveralls| image:: https://coveralls.io/repos/github/ansasaki/abimap/badge.svg?branch=master
     :alt: Coverage Status
     :target: https://coveralls.io/github/ansasaki/abimap?branch=master
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -10,7 +10,7 @@
     :alt: Travis-CI Build Status
     :target: https://travis-ci.org/ansasaki/abimap
 
-.. |coveralls| image:: https://coveralls.io/repos/ansasaki/abimap/badge.svg?branch=master
+.. |coveralls| image:: https://coveralls.io/repos/github/ansasaki/abimap/badge.svg?branch=master
     :alt: Coverage Status
     :target: https://coveralls.io/github/ansasaki/abimap?branch=master
 

--- a/docs/templates/readme.template
+++ b/docs/templates/readme.template
@@ -10,7 +10,7 @@
     :alt: Travis-CI Build Status
     :target: https://travis-ci.org/ansasaki/abimap
 
-.. |coveralls| image:: https://coveralls.io/repos/ansasaki/abimap/badge.svg?branch=master
+.. |coveralls| image:: https://coveralls.io/repos/github/ansasaki/abimap/badge.svg?branch=master
     :alt: Coverage Status
     :target: https://coveralls.io/github/ansasaki/abimap?branch=master
 

--- a/src/abimap/symver.py
+++ b/src/abimap/symver.py
@@ -731,7 +731,7 @@ class Map(object):
             self.logger.error(msg)
             raise Exception(msg)
 
-        self.releases.sort(key=lambda release: release.name)
+        self.releases.sort(key=lambda release: release.name, reverse=True)
         dependencies = self.dependencies()
         top_dependency = next((dependency for dependency in dependencies if
                                dependency[0] == top_release))

--- a/tests/data_template/test_as_lib/update_default_name.stdout
+++ b/tests/data_template/test_as_lib/update_default_name.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-BASE_1_1_0
-{
-    global:
-        symbol;
-} BASE_1_0_0;
-
 BASE_1_0_0
 {
     global:
@@ -16,4 +10,10 @@ BASE_1_0_0
     local:
         *;
 } ;
+
+BASE_1_1_0
+{
+    global:
+        symbol;
+} BASE_1_0_0;
 

--- a/tests/data_template/test_as_lib/update_different_name.stdout
+++ b/tests/data_template/test_as_lib/update_different_name.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with someapp-PROGRAM_VERSION
 
-BASE_1_1_0
-{
-    global:
-        symbol;
-} BASE_1_0_0;
-
 BASE_1_0_0
 {
     global:
@@ -16,4 +10,10 @@ BASE_1_0_0
     local:
         *;
 } ;
+
+BASE_1_1_0
+{
+    global:
+        symbol;
+} BASE_1_0_0;
 

--- a/tests/data_template/test_script/update_add.stdout
+++ b/tests/data_template/test_script/update_add.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-BASE_1_1_0
-{
-    global:
-        symbol;
-} BASE_1_0_0;
-
 BASE_1_0_0
 {
     global:
@@ -16,4 +10,10 @@ BASE_1_0_0
     local:
         *;
 } ;
+
+BASE_1_1_0
+{
+    global:
+        symbol;
+} BASE_1_0_0;
 

--- a/tests/data_template/test_update/add.outfile
+++ b/tests/data_template/test_update/add.outfile
@@ -1,11 +1,5 @@
 # This map file was updated with PROGRAM_NAME_VERSION
 
-LIBTC1_1_1_0
-{
-    global:
-        symbol;
-} LIBTC1_1_0_0;
-
 LIBTC1_1_0_0
 {
     global:
@@ -13,4 +7,10 @@ LIBTC1_1_0_0
     local:
         *;
 } ;
+
+LIBTC1_1_1_0
+{
+    global:
+        symbol;
+} LIBTC1_1_0_0;
 

--- a/tests/data_template/test_update/add_final.stdout
+++ b/tests/data_template/test_update/add_final.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-LIBTC1_1_1_0    # Released
-{
-    global:
-        symbol;
-} LIBTC1_1_0_0;
-
 LIBTC1_1_0_0
 {
     global:
@@ -16,4 +10,10 @@ LIBTC1_1_0_0
     local:
         *;
 } ;
+
+LIBTC1_1_1_0    # Released
+{
+    global:
+        symbol;
+} LIBTC1_1_0_0;
 

--- a/tests/data_template/test_update/add_present.stdout
+++ b/tests/data_template/test_update/add_present.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-ADD_PRESENT_1_1_0
-{
-    global:
-        symbol;
-} ADD_PRESENT_1_0_0;
-
 ADD_PRESENT_1_0_0
 {
     global:
@@ -16,4 +10,10 @@ ADD_PRESENT_1_0_0
     local:
         *;
 } ;
+
+ADD_PRESENT_1_1_0
+{
+    global:
+        symbol;
+} ADD_PRESENT_1_0_0;
 

--- a/tests/data_template/test_update/add_with_wildcard.stdout
+++ b/tests/data_template/test_update/add_with_wildcard.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-WITH_WILDCARD_1_1_0
-{
-    global:
-        symbol;
-} WITH_WILDCARD_1_0_0;
-
 WITH_WILDCARD_1_0_0
 {
     global:
@@ -17,4 +11,10 @@ WITH_WILDCARD_1_0_0
     local:
         *;
 } ;
+
+WITH_WILDCARD_1_1_0
+{
+    global:
+        symbol;
+} WITH_WILDCARD_1_0_0;
 

--- a/tests/data_template/test_update/circular_dependency.map
+++ b/tests/data_template/test_update/circular_dependency.map
@@ -1,23 +1,5 @@
 # Broken map with circular dependency
 
-LIBTC5_9_2_0
-{
-    global:
-        one_symbol;
-} LIBTC5_9_1_0;
-
-LIBTC5_9_1_0
-{
-    global:
-        two_symbol;
-} LIBTC5_9_0_0;
-
-LIBTC5_9_0_0
-{
-    global:
-        three_symbol;
-} LIBTC5_9_2_0;
-
 LIBBASE_1_0_0
 {
     global:
@@ -25,4 +7,22 @@ LIBBASE_1_0_0
     local:
         *;
 } ;
+
+LIBTC5_9_0_0
+{
+    global:
+        three_symbol;
+} LIBTC5_9_2_0;
+
+LIBTC5_9_1_0
+{
+    global:
+        two_symbol;
+} LIBTC5_9_0_0;
+
+LIBTC5_9_2_0
+{
+    global:
+        one_symbol;
+} LIBTC5_9_1_0;
 

--- a/tests/data_template/test_update/duplicated_dependency.map
+++ b/tests/data_template/test_update/duplicated_dependency.map
@@ -1,10 +1,12 @@
 # Broken map with duplicated dependency
 
-LIBTC5_9_1_0
+LIBTC5_9_0_0
 {
     global:
-        other_symbol;
-} LIBTC5_9_0_0;
+        one_more_symbol;
+    local:
+        *;
+} ;
 
 LIBTC5_9_0_0
 {
@@ -14,10 +16,9 @@ LIBTC5_9_0_0
         *;
 } ;
 
-LIBTC5_9_0_0
+LIBTC5_9_1_0
 {
     global:
-        one_more_symbol;
-    local:
-        *;
-} ;
+        other_symbol;
+} LIBTC5_9_0_0;
+

--- a/tests/data_template/test_update/duplicated_symbol.stdout
+++ b/tests/data_template/test_update/duplicated_symbol.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-DUPLICATED_1_1_0
-{
-    global:
-        symbol;
-} DUPLICATED_1_0_0;
-
 DUPLICATED_1_0_0
 {
     global:
@@ -17,4 +11,10 @@ DUPLICATED_1_0_0
     local:
         *;
 } ;
+
+DUPLICATED_1_1_0
+{
+    global:
+        symbol;
+} DUPLICATED_1_0_0;
 

--- a/tests/data_template/test_update/missing_global.stdout
+++ b/tests/data_template/test_update/missing_global.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-MISSING_GLOBAL_1_1_0
-{
-    global:
-        symbol;
-} MISSING_GLOBAL_1_0_0;
-
 MISSING_GLOBAL_1_0_0
 {
     global:
@@ -17,4 +11,10 @@ MISSING_GLOBAL_1_0_0
     local:
         *;
 } ;
+
+MISSING_GLOBAL_1_1_0
+{
+    global:
+        symbol;
+} MISSING_GLOBAL_1_0_0;
 

--- a/tests/data_template/test_update/mixed_names.stdout
+++ b/tests/data_template/test_update/mixed_names.stdout
@@ -3,23 +3,17 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-ROGUE_RELEASE_4_6_0
-{
-    global:
-        symbol;
-} ROGUE_RELEASE_4_5_6;
-
 ROGUE_RELEASE_4_5_6
 {
     global:
         three_symbol;
 } ;
 
-OTHER_DIFFERENT_NAME_1_1_0
+ROGUE_RELEASE_4_6_0
 {
     global:
-        two_symbol;
-} NAME_1_0_0;
+        symbol;
+} ROGUE_RELEASE_4_5_6;
 
 NAME_1_0_0
 {
@@ -28,4 +22,10 @@ NAME_1_0_0
     local:
         *;
 } ;
+
+OTHER_DIFFERENT_NAME_1_1_0
+{
+    global:
+        two_symbol;
+} NAME_1_0_0;
 

--- a/tests/data_template/test_update/non_existing_previous.map
+++ b/tests/data_template/test_update/non_existing_previous.map
@@ -1,11 +1,5 @@
 # Broken map with non-existing dependency
 
-LIBTC5_8_1_0
-{
-    global:
-        other_symbol;
-} LIBTC5_8_0_0;
-
 LIBBASE_1_0_0
 {
     global:
@@ -13,3 +7,10 @@ LIBBASE_1_0_0
     local:
         *;
 } ;
+
+LIBTC5_8_1_0
+{
+    global:
+        other_symbol;
+} LIBTC5_8_0_0;
+

--- a/tests/data_template/test_update/only_visibility.stdout
+++ b/tests/data_template/test_update/only_visibility.stdout
@@ -3,15 +3,15 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-ONLY_VISIBILITY_1_1_0
-{
-    global:
-        symbol;
-} ONLY_VISIBILITY_1_0_0;
-
 ONLY_VISIBILITY_1_0_0
 {
     global:
     local:
 } ;
+
+ONLY_VISIBILITY_1_1_0
+{
+    global:
+        symbol;
+} ONLY_VISIBILITY_1_0_0;
 

--- a/tests/data_template/test_update/sanity_add.stdout
+++ b/tests/data_template/test_update/sanity_add.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-LIBTC1_1_1_0
-{
-    global:
-        symbol;
-} LIBTC1_1_0_0;
-
 LIBTC1_1_0_0
 {
     global:
@@ -16,4 +10,10 @@ LIBTC1_1_0_0
     local:
         *;
 } ;
+
+LIBTC1_1_1_0
+{
+    global:
+        symbol;
+} LIBTC1_1_0_0;
 

--- a/tests/data_template/test_update/split.stdout
+++ b/tests/data_template/test_update/split.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-SPLIT_1_1_0
-{
-    global:
-        symbol;
-} SPLIT_1_0_0;
-
 SPLIT_1_0_0
 {
     global:
@@ -17,4 +11,10 @@ SPLIT_1_0_0
     local:
         *;
 } ;
+
+SPLIT_1_1_0
+{
+    global:
+        symbol;
+} SPLIT_1_0_0;
 

--- a/tests/data_template/test_update/symbols.out
+++ b/tests/data_template/test_update/symbols.out
@@ -1,11 +1,5 @@
 # This map file was updated with PROGRAM_NAME_VERSION
 
-LIBTC3_1_1_0
-{
-    global:
-        new_symbol;
-} LIBTC3_1_0_0;
-
 LIBTC3_1_0_0
 {
     global:
@@ -14,4 +8,10 @@ LIBTC3_1_0_0
     local:
         *;
 } ;
+
+LIBTC3_1_1_0
+{
+    global:
+        new_symbol;
+} LIBTC3_1_0_0;
 

--- a/tests/data_template/test_update/symbols_final.stdout
+++ b/tests/data_template/test_update/symbols_final.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-LIBTC3_1_1_0    # Released
-{
-    global:
-        new_symbol;
-} LIBTC3_1_0_0;
-
 LIBTC3_1_0_0
 {
     global:
@@ -17,4 +11,10 @@ LIBTC3_1_0_0
     local:
         *;
 } ;
+
+LIBTC3_1_1_0    # Released
+{
+    global:
+        new_symbol;
+} LIBTC3_1_0_0;
 

--- a/tests/data_template/test_update/symbols_sanity.stdout
+++ b/tests/data_template/test_update/symbols_sanity.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-LIBTC3_1_1_0
-{
-    global:
-        new_symbol;
-} LIBTC3_1_0_0;
-
 LIBTC3_1_0_0
 {
     global:
@@ -17,4 +11,10 @@ LIBTC3_1_0_0
     local:
         *;
 } ;
+
+LIBTC3_1_1_0
+{
+    global:
+        new_symbol;
+} LIBTC3_1_0_0;
 

--- a/tests/data_template/test_update/with_release_info.stdout
+++ b/tests/data_template/test_update/with_release_info.stdout
@@ -3,12 +3,6 @@ Added:
 
 # This map file was updated with PROGRAM_NAME_VERSION
 
-WITH_RELEASE_INFO_1_0_0
-{
-    global:
-        symbol;
-} BASE_1_0_0;
-
 BASE_1_0_0
 {
     global:
@@ -16,4 +10,10 @@ BASE_1_0_0
     local:
         *;
 } ;
+
+WITH_RELEASE_INFO_1_0_0
+{
+    global:
+        symbol;
+} BASE_1_0_0;
 


### PR DESCRIPTION
This order the releases in reverse order, with older versions first.
The tests were fixed accordingly.

fixes #75 