### PR TITLE
Use natural sort to order releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ lint: ## check style with flake8
 	flake8 src/abimap tests
 
 test: bootstrap-tests## run tests quickly with the default Python
-	pytest -vv --ignore=src/
+	PYTHONPATH=src/ pytest -vv --ignore=src/
 
 test-all: tox.ini## run tests on every Python version with tox
 	tox

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from os.path import splitext
 
 from setuptools import find_packages
 from setuptools import setup
+
 from version import get_version
 
 package_name = "abimap"
@@ -21,7 +22,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['setuptools']
+requirements = ['setuptools', 'natsort']
 
 setup_requirements = ['pytest-runner']
 

--- a/src/abimap/symver.py
+++ b/src/abimap/symver.py
@@ -8,6 +8,8 @@ import shutil
 import sys
 from itertools import chain
 
+from natsort import natsorted
+
 from ._version import __version__
 
 VERBOSITY_MAP = {"debug": logging.DEBUG,
@@ -736,7 +738,7 @@ class Map(object):
             self.logger.error(msg)
             raise Exception(msg)
 
-        self.releases.sort(key=lambda release: release.name, reverse=True)
+        self.releases = natsorted(self.releases, key=lambda release: release.name, reverse=True)
         dependencies = self.dependencies()
         top_dependency = next((dependency for dependency in dependencies if
                                dependency[0] == top_release))

--- a/tests/data_template/test_update/add.yaml
+++ b/tests/data_template/test_update/add.yaml
@@ -200,3 +200,16 @@
     warnings:
     errors:
     exceptions:
+-
+  input:
+    args:
+      - "update"
+      - "--add"
+      - "add_10.map"
+    stdin: "symbol.in"
+  output:
+    file:
+    stdout: "add_10.stdout"
+    warnings:
+    errors:
+    exceptions:

--- a/tests/data_template/test_update/add_10.map
+++ b/tests/data_template/test_update/add_10.map
@@ -1,0 +1,11 @@
+# This map file was created with PROGRAM_NAME_VERSION
+
+LIBTC1_1_9_0
+{
+    global:
+        another_symbol;
+    local:
+        *;
+} ;
+
+

--- a/tests/data_template/test_update/add_10.stdout
+++ b/tests/data_template/test_update/add_10.stdout
@@ -1,0 +1,19 @@
+Added:
+    symbol
+
+# This map file was updated with PROGRAM_NAME_VERSION
+
+LIBTC1_1_9_0
+{
+    global:
+        another_symbol;
+    local:
+        *;
+} ;
+
+LIBTC1_1_10_0
+{
+    global:
+        symbol;
+} LIBTC1_1_9_0;
+


### PR DESCRIPTION
This allows sorting the versions 1.10 after 1.9.

Fixes #88.

Only partially tested in python3 prompt as the `make test` behavior